### PR TITLE
issue#21の修正

### DIFF
--- a/HttpConnection/autoindex.cpp
+++ b/HttpConnection/autoindex.cpp
@@ -37,8 +37,6 @@ static std::string getDisplayedDate(const struct dirent *entry, std::string path
     std::string path(path_fixed);
     path += entry->d_name;
     struct stat path_stat;
-    if (stat(path.c_str(), &path_stat) < 0)
-        perror("stat");
     char date_str[256];
     struct tm *mtime = gmtime(&path_stat.st_mtimespec.tv_sec);
     strftime(date_str, 256, "%d-%b-%Y %H:%M", mtime);
@@ -52,8 +50,6 @@ static std::string getDisplayedSize(const struct dirent *entry, std::string path
     std::string path(path_fixed);
     path += entry->d_name;
     struct stat path_stat;
-    if (stat(path.c_str(), &path_stat) < 0)
-        perror("stat");
     std::stringstream ss;
     if (S_ISDIR(path_stat.st_mode))
         ss << "-";

--- a/request/RequestParse.cpp
+++ b/request/RequestParse.cpp
@@ -216,6 +216,9 @@ void RequestParse::createPathFromConfRoot(){
     pathFromConfRoot = location->locationSetting["root"] + rawPath.substr(1);
     if(pathFromConfRoot == "")
         pathFromConfRoot = "./";
+    if (pathFromConfRoot.length() > 0 && pathFromConfRoot[pathFromConfRoot.length() - 1] == '/') {
+        pathFromConfRoot.erase(pathFromConfRoot.length() - 1); // 最後の文字を削除
+    }
 }
 
 


### PR DESCRIPTION
リクエスト際末尾に/がないと解釈されない　
->　正しくはGETリクエストの際に末尾に/があると解釈されない？

discordのwebservの仕様を参考に、
localost/sample.html　で表示される内容を　localost/sample.html/　でも表示されるよう修正。