### PR TITLE
issue#28の修正

### DIFF
--- a/HttpConnection/HttpConnection.hpp
+++ b/HttpConnection/HttpConnection.hpp
@@ -31,6 +31,10 @@ typedef struct progressInfo{
     int tmpKind;
     std::string requestPath;
 
+    bool sendFlag;
+    int sendKind;
+    std::string sendResponse;
+
 } progressInfo;
 
 typedef struct timespec timespec;
@@ -123,6 +127,7 @@ class HttpConnection{
         static void deleteCgiHeader(std::string &responseHeaders);
         static std::string addAnnotationToLoginPage(std::string annotation);
 
+        void handleSend(progressInfo *obj);
 
 };
 

--- a/HttpConnection/autoindex.cpp
+++ b/HttpConnection/autoindex.cpp
@@ -137,7 +137,10 @@ void HttpConnection::sendAutoindexPage(RequestParse& requestInfo, progressInfo *
     } else if (info.st_mode & S_IFDIR) {
         // パスがディレクトリである場合
         std::string response = createAutoindexPage(requestInfo, path);
-        sendToClient(response, obj, NORMAL);
+        obj->sendResponse = response;
+        obj->sendKind = NORMAL;
+        obj->sendFlag = true;
+        // sendToClient(response, obj, NORMAL);
     } else {
         // パスがディレクトリではない場合(ファイルの時)
         return sendStaticPage(requestInfo, obj);

--- a/HttpConnection/http_utils.cpp
+++ b/HttpConnection/http_utils.cpp
@@ -80,7 +80,10 @@ void HttpConnection::sendRedirectPage(Location* location, progressInfo *obj)
     response += "Location: " + location->locationSetting["return"] + "\n";
     response += "\n";//ヘッダーとボディを分けるために、ボディが空でも必要
 
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 
 }
 
@@ -114,7 +117,10 @@ void HttpConnection::sendDefaultErrorPage(VirtualServer* server, progressInfo *o
     response += "\n";
     response += content;
 
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 }
 
 // サーバーからのレスポンスとして静的ファイルを送る関数
@@ -163,9 +169,16 @@ void HttpConnection::sendStaticPage(RequestParse& requestInfo, progressInfo *obj
     response += "\n";
     response += content;
     if(requestInfo.getHeader("Connection") == "close"){
-        return sendToClient(response, obj, CLOSE);
+        obj->sendResponse = response;
+        obj->sendKind = CLOSE;
+        obj->sendFlag = true;
+        return ;
+        // return sendToClient(response, obj, CLOSE);
     }
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 }
 
 bool HttpConnection::checkCompleteRecieved(progressInfo obj){
@@ -254,7 +267,10 @@ void HttpConnection::sendLoginPage(int status, RequestParse& requestInfo, progre
         response += "Location: " + redirectPath + "\n";
         response += "\n";
         response += "Login successful";
-        sendToClient(response, obj, NORMAL);
+        obj->sendResponse = response;
+        obj->sendKind = NORMAL;
+        obj->sendFlag = true;
+        // sendToClient(response, obj, NORMAL);
         return ;
     }
     std::string content = getStringFromHtml("documents/login.html");
@@ -267,7 +283,10 @@ void HttpConnection::sendLoginPage(int status, RequestParse& requestInfo, progre
     response += "Content-Type: text/html\n";
     response += "\n";
     response += content;
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 }
 
 void HttpConnection::sendUserPage(std::vector<std::string> userInfo, int status, RequestParse& requestInfo, progressInfo *obj){
@@ -285,7 +304,10 @@ void HttpConnection::sendUserPage(std::vector<std::string> userInfo, int status,
         response += "\n";
         response += "Login successful";
 
-        sendToClient(response, obj, NORMAL);
+        obj->sendResponse = response;
+        obj->sendKind = NORMAL;
+        obj->sendFlag = true;
+        // sendToClient(response, obj, NORMAL);
         return ;
    }
    std::ifstream ifs("documents/user.html");
@@ -312,7 +334,10 @@ void HttpConnection::sendUserPage(std::vector<std::string> userInfo, int status,
     response += "Content-Type: text/html\n";
     response += "\n";
     response += content;
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 }
 
 

--- a/HttpConnection/post_delete_utils.cpp
+++ b/HttpConnection/post_delete_utils.cpp
@@ -28,7 +28,10 @@ void HttpConnection::sendBadRequestPage(progressInfo *obj)
     response += "\n";
     response += content;
 
-    sendToClient(response, obj, BAD_REQ);
+    obj->sendResponse = response;
+    obj->sendKind = BAD_REQ;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, BAD_REQ);
 }
 
 void HttpConnection::sendForbiddenPage(progressInfo *obj)
@@ -45,7 +48,10 @@ void HttpConnection::sendForbiddenPage(progressInfo *obj)
     response += "\n";
     response += content;
 
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 }
 
 void HttpConnection::sendNotAllowedPage(progressInfo *obj)
@@ -62,7 +68,10 @@ void HttpConnection::sendNotAllowedPage(progressInfo *obj)
     response += "\n";
     response += content;
 
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 
 }
 
@@ -80,7 +89,10 @@ void HttpConnection::requestEntityPage(progressInfo *obj)
     response += "\n";
     response += content;
 
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 }
 
 void HttpConnection::sendNotImplementedPage(progressInfo *obj)
@@ -97,7 +109,10 @@ void HttpConnection::sendNotImplementedPage(progressInfo *obj)
     response += "\n";
     response += content;
 
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 }
 
 void HttpConnection::sendTimeoutPage(progressInfo *obj)
@@ -118,7 +133,10 @@ void HttpConnection::sendTimeoutPage(progressInfo *obj)
     response += "\n";
     response += content;
 
-    obj->httpConnection->sendToClient(response, obj, CGI_FAIL);
+    obj->sendResponse = response;
+    obj->sendKind = CGI_FAIL;
+    obj->sendFlag = true;
+    // obj->httpConnection->sendToClient(response, obj, CGI_FAIL);
 }
 
 void HttpConnection::sendInternalErrorPage(progressInfo *obj, int kind)
@@ -135,7 +153,10 @@ void HttpConnection::sendInternalErrorPage(progressInfo *obj, int kind)
     response += "\n";
     response += content;
 
-    sendToClient(response, obj, kind);
+    obj->sendResponse = response;
+    obj->sendKind = kind;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, kind);
 }
 
 // GETのcgi関数と違うのはPOSTメソッドで届いたクライアントからのリクエストボディをexecveの引数に渡すところ
@@ -208,5 +229,8 @@ void HttpConnection::deleteProcess(RequestParse& requestInfo, progressInfo *obj)
     response += "Server: webserv/1.0.0\n";
     response += "\n";//ヘッダーとボディを分けるために、ボディが空でも必要
 
-    sendToClient(response, obj, NORMAL);
+    obj->sendResponse = response;
+    obj->sendKind = NORMAL;
+    obj->sendFlag = true;
+    // sendToClient(response, obj, NORMAL);
 }

--- a/HttpConnection/post_delete_utils.cpp
+++ b/HttpConnection/post_delete_utils.cpp
@@ -137,6 +137,7 @@ void HttpConnection::sendTimeoutPage(progressInfo *obj)
     obj->sendKind = CGI_FAIL;
     obj->sendFlag = true;
     // obj->httpConnection->sendToClient(response, obj, CGI_FAIL);
+    createNewEvent(obj->socket, EVFILT_WRITE, EV_ADD | EV_ONESHOT, 0, 0, obj);
 }
 
 void HttpConnection::sendInternalErrorPage(progressInfo *obj, int kind)


### PR DESCRIPTION
objが次にsendするかどうかをsendFlagで管理。
sendToClient()の呼び出しをメインループの中で一度きりにすることでsendとreadやrecvの競合を防ぐ。